### PR TITLE
Add check for mismatch of operations in history

### DIFF
--- a/src/elle/list_append.clj
+++ b/src/elle/list_append.clj
@@ -298,6 +298,27 @@
                         :duplicates dups})))))
        seq))
 
+(defn op-mismatch
+  "Given a history, find mismatches of mop invocations to its completion.
+  They should match exactly except for [:r k nil], which can match any
+  [:r k v]."
+  [history]
+  (->> history
+       pair-index
+       ; Only take invoke/complete pairs
+       (filter (fn [[invoke complete]] (= (:type invoke) :invoke)))
+       ; map to vector of mops pairs: (([pair pair]), (pairs), ...)
+       (map (fn [[invoke complete]] (map vector (:value invoke) (:value complete))))
+       ; -> [([pair pair]), (pairs), ...]
+       (into [])
+       (map (partial filter (fn [[invoke complete]]
+                              (not
+                                (if (and (= (first invoke) :r) (= (last invoke) nil))
+                                  (and (= (first complete) :r) (= (second invoke) (second complete)))
+                                  (= invoke complete))))))
+       (keep seq)
+       seq))
+
 (defn merge-orders
   "Takes two potentially incompatible read orders (sequences of elements), and
   computes a total order which is consistent with both of them: where there are
@@ -758,6 +779,7 @@
    (check {} history))
   ([opts history]
    (let [history      (remove (comp #{:nemesis} :process) history)
+         op-mismatch  (op-mismatch history)
          g1a          (g1a-cases history)
          g1b          (g1b-cases history)
          internal     (internal-cases history)
@@ -778,6 +800,7 @@
 
          ; And merge in our own anomalies
          anomalies (cond-> cycles
+                     op-mismatch    (assoc :op-mismatch op-mismatch)
                      dups           (assoc :duplicate-elements dups)
                      incmp-order    (assoc :incompatible-order incmp-order)
                      internal       (assoc :internal internal)


### PR DESCRIPTION
This is intended to fix https://github.com/jepsen-io/maelstrom/issues/14

I can see the result by injecting the `op-mismatch` as `:internal` anomalies, which will (cause `maelstrom` to) output like this if I simply use `append` for all µ-op functions:

```
 :workload {:valid? false,
            :anomaly-types (:internal),
            :anomalies {:internal (([[:r 6 nil] [:append 6 nil]])
                                   ([[:r 9 nil] [:append 9 [1]]]
                                    [[:r 9 nil] [:append 9 [1]]])
                                   ([[:r 9 nil] [:append 9 nil]]
                                    [[:r 8 nil] [:append 8 nil]])
                                   ([[:r 8 nil] [:append 8 nil]]))},
```

I still need to find a place to let the checker realize the `:op-mismatch` anomalies though, it seems I would need to add it somewhere in `consistency_model.clj`? And at this point I'm not sure if this should be considered as a "consistency model", or which one (I'm interested in this field but I'm not fluent in the terminologies). Could you point out where I should add it?

Also this is my first time contributing to Clojure projects (actually first time working on any Clojure projects), so kindly inform me if there're better ways to approach things. There're also probably some excessive comments, let me know if they should be removed.

And obviously the error message/return should be improved.