### PR TITLE
Fix jepsen.io link in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,7 +27,7 @@ formalization of its soundness proof. A nowhere-near-complete formal
 [proof](proof/) sketch is written in the
 [Isabelle/HOL](https://isabelle.in.tum.de/) proof language.
 
-If you want to check a database using Elle, see [https://jepsen.io](Jepsen); Elle comes built-in. If you want to use Elle to check your own histories without using Jepsen, you can add Elle as a dependency to any JVM project, and invoke its checker functions directly. If you're working in a non-JVM language, you can write your history to a file or stream, and call a small wrapper program to produce output.
+If you want to check a database using Elle, see [Jepsen](https://jepsen.io); Elle comes built-in. If you want to use Elle to check your own histories without using Jepsen, you can add Elle as a dependency to any JVM project, and invoke its checker functions directly. If you're working in a non-JVM language, you can write your history to a file or stream, and call a small wrapper program to produce output.
 
 Elle is still under active development, and we're not 100% confident in its
 inference rules yet. Jepsen recommends checking reported anomalies by hand to


### PR DESCRIPTION
I noticed that this link went... nowhere that looked even slightly correct.
So here's a fix!