### PR TITLE
Remove dead code

### DIFF
--- a/src/elle/list_append.clj
+++ b/src/elle/list_append.clj
@@ -699,12 +699,6 @@
                            history))
      :explainer (RWExplainer. append-index write-index read-index)}))
 
-(defn g1c-graph
-  "Per Adya, Liskov, & O'Neil, phenomenon G1C encompasses any cycle made up of
-  direct dependency edges (but does not include anti-dependencies)."
-  [history]
-  ((elle/combine ww-graph wr-graph) history))
-
 (defn graph
   "Some parts of a transaction's dependency graph--for instance,
   anti-dependency cycles--involve the *version order* of states for a key.

--- a/src/elle/txn.clj
+++ b/src/elle/txn.clj
@@ -33,11 +33,6 @@
        (keep f)
        seq))
 
-(defn all-keys
-  "A sequence of all unique keys in the given history."
-  [history]
-  (->> history op-mops (map (comp second second)) distinct))
-
 (def integer-types
   #{Byte Short Integer Long})
 


### PR DESCRIPTION
I have run elle's regression test suite with cloverage, the project has a nice code coverage! However, some functions are not covered by tests and unused at all. These functions look as a dead code: `txn/all-keys`, `rw-register/gen`, `list-append/g1c-graph` and seems can be removed.

HTML report generated by Cloverage: https://bronevichok.ru/static/elle-coverage/