### PR TITLE
Disable profiler

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
   :jvm-opts ["-server"
              ;"-XX:-OmitStackTraceInFastThrow"
              ;"-XX:+PrintGC"
-             "-agentpath:/home/aphyr/yourkit/bin/linux-x86-64/libyjpagent.so=disablestacktelemetry,exceptions=disable,delay=10000,usedmem=50"
+             ;"-agentpath:/home/aphyr/yourkit/bin/linux-x86-64/libyjpagent.so=disablestacktelemetry,exceptions=disable,delay=10000,usedmem=50"
              ]
   :repl-options {:init-ns elle.core}
   :test-selectors {:default (fn [m] (not (or (:perf m)


### PR DESCRIPTION
`lein repl` couldn't find shared library:
```
Error occurred during initialization of VM
Could not find agent library /home/aphyr/yourkit/bin/linux-x86-64/libyjpagent.so in absolute path, with error: /home/aphyr/yourkit/bin/linux
-x86-64/libyjpagent.so: cannot open shared object file: No such file or directory
```