### PR TITLE
core/check: call write-cycles! correctly

### DIFF
--- a/src/elle/core.clj
+++ b/src/elle/core.clj
@@ -536,14 +536,21 @@
   returns a [graph, explainer] pair, and returns a checker which uses those
   graphs to identify cyclic dependencies. Options are:
 
-  {:analyzer    A function which takes a history and returns a {:graph,
-  :explainer, :anomalies} map; e.g. realtime-graph.
+  {:analyzer   A function which takes a history and returns a 
+               {:graph, :explainer, :anomalies} map; e.g. realtime-graph.
   :directory   Where to write results}"
   [opts history]
   (try+
     (let [analyze-fn (:analyzer opts)
           {:keys [graph explainer sccs cycles]} (check- analyze-fn history)]
-      (write-cycles! opts cycles)
+      (when (and (seq sccs)
+                 (:directory opts))
+        (let [opts      (assoc opts :pair-explainer explainer)
+              explained (->> sccs ; write-cycles! wants explained cycles
+                          (map #(->> (bg/select graph (bs/from %))
+                                     g/find-cycle
+                                     (explain-cycle cycle-explainer explainer))))]
+          (write-cycles! opts explained)))
       {:valid?     (empty? sccs)
        :scc-count  (count sccs)
        :cycles     cycles})

--- a/test/elle/core_test.clj
+++ b/test/elle/core_test.clj
@@ -86,11 +86,15 @@
           r11' {:index 5 :type :ok     :process 0 :f :read :value {:x 1 :y 1}}
           r01  {:index 6 :type :invoke :process 0 :f :read :value nil}
           r01' {:index 7 :type :ok     :process 0 :f :read :value {:x 0 :y 1}}
-          history (h/history [r00 r00' r10 r10' r11 r11' r01 r01'])]
+          history (h/history [r00 r00' r10 r10' r11 r11' r01 r01'])
+          msg "Let:\n  T1 = {:index 7, :time -1, :type :ok, :process 0, :f :read, :value {:x 0, :y 1}}\n  T2 = {:index 3, :time -1, :type :ok, :process 0, :f :read, :value {:x 1, :y 0}}\n\nThen:\n  - T1 < T2, because T1 observed :x = 0, and T2 observed a higher value 1.\n  - However, T2 < T1, because T2 observed :y = 0, and T1 observed a higher value 1: a contradiction!"]
       (is (= {:valid? false
               :scc-count 1
-              :cycles ["Let:\n  T1 = {:index 3, :time -1, :type :ok, :process 0, :f :read, :value {:x 1, :y 0}}\n  T2 = {:index 7, :time -1, :type :ok, :process 0, :f :read, :value {:x 0, :y 1}}\n\nThen:\n  - T1 < T2, because T1 observed :y = 0, and T2 observed a higher value 1.\n  - However, T2 < T1, because T2 observed :x = 0, and T1 observed a higher value 1: a contradiction!"]}
-             (check {:analyzer monotonic-key-graph} history)))))
+              :cycles [msg]}
+             (check {:analyzer  monotonic-key-graph
+                     :directory "test-output/checker-test/invalid/sccs"}
+                    history)))
+      (is (= (str "Cycle #0\n" msg) (slurp "test-output/checker-test/invalid/sccs/cycles.txt")))))
 
   (testing "large histories"
     (let [history (->> (range)


### PR DESCRIPTION
Hi,

`core/check` isn't calling `core/write-cycles!` correctly, so output files are empty.

```
Cycle #0
Let:

Then:

```

I think it might have fallen behind as `list_append` and `txn` use `core/check-`, `txn` calls `core/write-cycles!` directly, and so on.

----

Update `core/check`:
  - set `:pair-explainer`
  - convert and pass `sccs` explained but not rendered to `write-cycles!`

Update `core_test`
  - use `:directory` and compare file contents to rendered cycle
