### PR TITLE
Add optional `:transaction-order` argument to rw_register/check (addresses #30)

### DIFF
--- a/src/elle/rw_register.clj
+++ b/src/elle/rw_register.clj
@@ -202,6 +202,54 @@
           {}
           history))
 
+
+(defn history-with-txn-versions
+  "Takes a history and a mapping from transaction completion indices to transaction orders
+   and annotates each history event with this info as a :version field."
+  [history transaction-order]
+  (map (fn [op]
+         (if (contains? transaction-order (:index op))
+           (assoc op :version (get transaction-order (:index op)))
+           op))
+       history))
+
+(defn key-writes-version-sorted 
+  "Given a history where every op is annotated with a numeric 'version' for the
+   writes in that op, generate a map of keys to a vector of all values (i.e.
+   versions) written to that key, sorted ascendingly by version."
+  [history]
+  (->
+    (reduce (fn [m op]
+            (if (or (h/invoke? op)
+                    (h/fail?   op))
+              m
+              (let [txn (:value op)
+                    writes (txn/ext-writes txn)
+                    version (:version op)]
+                (reduce (fn [m [k v]] (update m k (fn [vs] (conj vs {:value v :version version})))) m writes))))
+            {}
+            history)
+    (update-vals ,,, (fn [vs] (sort-by :version vs)))
+  )
+)
+
+(defn transaction-order-graphs
+  "Take a mapping from transaction event completion indices to a transaction total order and 
+   returns a map from keys to version graphs inferred from the transaction order. That is,
+   we assume that each key written in a transaction is assigned the version of its owning transaction."
+  [history opts]
+  (let [versionEdgeMap (-> 
+      ;; Extract map of writes for each key, sorted ascending by version.
+      (key-writes-version-sorted (history-with-txn-versions history (:transaction-order opts))) 
+      ;; Convert each ascending version write list into list of version graph edges.
+      ;; e.g. write list [w1,w2,w3] into edges [[w1 w2] [w2 w3]]
+      (update-vals ,,, (fn [vs] (partition 2 1 (sort-by :version vs)))))
+    ]              
+   ;; Now, for each key in the map of keys, reduce over its list of version graph edges,
+   ;; building the version graph for that key.
+   (update-vals versionEdgeMap (fn [edges] (reduce (fn [vg [ei ej]] (g/link vg (:value ei) (:value ej))) (g/digraph) edges)))
+))
+
 (defn wfr-version-graphs
   "If we assume that within a transaction, writes follow reads, then we can
   infer the version order wherever a transaction performs an external read of
@@ -578,6 +626,10 @@
   [opts history]
   (loop [analyzers (cond-> [{:name    :initial-state
                              :grapher initial-state-version-graphs}]
+                      
+                     (:transaction-order opts)
+                     (conj {:name     :transaction-order-keys
+                            :grapher  (fn [history] (transaction-order-graphs history opts))})
 
                      (:wfr-keys? opts)
                      (conj {:name     :wfr-keys
@@ -844,6 +896,12 @@
     :additional-graphs      A collection of graph analyzers (e.g. realtime)
                             which should be merged with our own dependency
                             graph.
+   
+    :transaction-order      A map from completed transaction operation indices in the history
+                            to a numeric, total transaction order. This is used to allow external, 
+                            'whitebox' dependency order information from a database system to be passed in 
+                            for automatic inference of additional dependency edges. Assumes that events
+                            in the given history can be uniquely identified by their :index fields.
 
     :cycle-search-timeout   How many milliseconds are we willing to search a
                             single SCC for a cycle?

--- a/src/elle/rw_register.clj
+++ b/src/elle/rw_register.clj
@@ -202,53 +202,42 @@
           {}
           history))
 
-
-(defn history-with-txn-versions
-  "Takes a history and a mapping from transaction completion indices to transaction orders
-   and annotates each history event with this info as a :version field."
-  [history transaction-order]
-  (map (fn [op]
-         (if (contains? transaction-order (:index op))
-           (assoc op :version (get transaction-order (:index op)))
-           op))
-       history))
-
 (defn key-writes-version-sorted 
-  "Given a history where every op is annotated with a numeric 'version' for the
-   writes in that op, generate a map of keys to a vector of all values (i.e.
-   versions) written to that key, sorted ascendingly by version."
-  [history]
+  "Given a history and a mapping from transaction completion indices to 
+   transaction orders, generate a map of keys to a vector of all values (i.e.
+   versions) written to that key, sorted ascending by version."
+  [history transaction-order]
   (->
     (reduce (fn [m op]
             (if (or (h/invoke? op)
                     (h/fail?   op))
               m
-              (let [txn (:value op)
+              (let [op-with-version (if (contains? transaction-order (:index op))
+                                    (assoc op :version (get transaction-order (:index op)))
+                                    op) 
+                    txn (:value op-with-version)
                     writes (txn/ext-writes txn)
-                    version (:version op)]
+                    version (:version op-with-version)]
                 (reduce (fn [m [k v]] (update m k (fn [vs] (conj vs {:value v :version version})))) m writes))))
             {}
             history)
-    (update-vals ,,, (fn [vs] (sort-by :version vs)))
-  )
-)
+    (update-vals (fn [vs] (map :value (sort-by :version vs))))))
 
 (defn transaction-order-graphs
-  "Take a mapping from transaction event completion indices to a transaction total order and 
+  "Take a history and a mapping from transaction event completion indices to a transaction total order and 
    returns a map from keys to version graphs inferred from the transaction order. That is,
    we assume that each key written in a transaction is assigned the version of its owning transaction."
-  [history opts]
-  (let [versionEdgeMap (-> 
+  [history transaction-order]
+    (-> 
       ;; Extract map of writes for each key, sorted ascending by version.
-      (key-writes-version-sorted (history-with-txn-versions history (:transaction-order opts))) 
-      ;; Convert each ascending version write list into list of version graph edges.
-      ;; e.g. write list [w1,w2,w3] into edges [[w1 w2] [w2 w3]]
-      (update-vals ,,, (fn [vs] (partition 2 1 (sort-by :version vs)))))
-    ]              
-   ;; Now, for each key in the map of keys, reduce over its list of version graph edges,
-   ;; building the version graph for that key.
-   (update-vals versionEdgeMap (fn [edges] (reduce (fn [vg [ei ej]] (g/link vg (:value ei) (:value ej))) (g/digraph) edges)))
-))
+      (key-writes-version-sorted history transaction-order) 
+      ;; For each key, build its version graph from its list of version graph edges.
+      (update-vals (fn [vs]
+                   ;; Convert the ascending version write list into list of version graph edges
+                   ;; e.g. write list [w1,w2,w3] into edges [[w1 w2] [w2 w3]]
+                   (let [edges (partition 2 1 vs)]
+                     ;; Add each edge to the version graph.
+                     (reduce (fn [vg [ei ej]] (g/link vg ei ej)) (g/digraph) edges))))))
 
 (defn wfr-version-graphs
   "If we assume that within a transaction, writes follow reads, then we can
@@ -629,7 +618,7 @@
                       
                      (:transaction-order opts)
                      (conj {:name     :transaction-order-keys
-                            :grapher  (fn [history] (transaction-order-graphs history opts))})
+                            :grapher  (fn [history] (transaction-order-graphs history (:transaction-order opts)))})
 
                      (:wfr-keys? opts)
                      (conj {:name     :wfr-keys
@@ -897,7 +886,7 @@
                             which should be merged with our own dependency
                             graph.
    
-    :transaction-order      A map from completed transaction operation indices in the history
+    :transaction-order      A map from completion transaction operation indices in the history
                             to a numeric, total transaction order. This is used to allow external, 
                             'whitebox' dependency order information from a database system to be passed in 
                             for automatic inference of additional dependency edges. Assumes that events

--- a/test/elle/rw_register_test.clj
+++ b/test/elle/rw_register_test.clj
@@ -433,6 +433,87 @@
                (c {:consistency-models [:repeatable-read]}
                   h)))))
 
+      (testing "G-single transaction-order"
+        (let [
+              t1 (op "rx_wy2")
+              t2 (op "wx3wy4")
+              [t1 t2 :as h] (h/history [t1 t2])
+              msg {:cycle [t1 t2 t1]
+                   :steps
+                   [{:type :rw,
+                     :key :x,
+                     :value nil,
+                     :value' 3,
+                     :a-mop-index 0,
+                     :b-mop-index 0}
+                    {:type :ww,
+                     :key :y,
+                     :value 4,
+                     :value' 2,
+                     :a-mop-index 1,
+                     :b-mop-index 1}],
+                   :type :G-single-item}]
+          ; Without explicit transaction order specified, the rw edge between T1 and T2 will not be inferred.
+          (is (= {:valid? true}
+                 (c {:consistency-models [:serializable]}
+                    h)))
+          ;; With explicitly specified transaction order, the rw edge will be inferred and G-single should manifest
+          (is (= {:valid? false
+                  :anomaly-types [:G-single-item]
+                  :not       #{:consistent-view :repeatable-read}
+                  :anomalies {:G-single-item [msg]}}
+                 (c {:consistency-models [:serializable] 
+                     ;; Txn commit order: T2 -> T1
+                     :transaction-order {0 2 1 1}}
+                    h)))          
+          ))
+    
+    (testing "G2-item transaction-order"
+      (let [t1 (op "wx1wy2wz3")
+            t2 (op "rx1wy5")
+            t3 (op "rz3wx4")
+            t4 (op "wz7wy8")
+            [t1 t2 t3 t4 :as h] (h/history [t1 t2 t3 t4])
+            msg {:cycle [t2 t3 t4 t2]
+                 :steps
+                 [{:type :rw,
+                   :key :x,
+                   :value 1,
+                   :value' 4,
+                   :a-mop-index 0,
+                   :b-mop-index 1}
+                  {:type :rw,
+                   :key :z,
+                   :value 3,
+                   :value' 7,
+                   :a-mop-index 0,
+                   :b-mop-index 0}
+                  {:type :ww,
+                   :key :y,
+                   :value 8,
+                   :value' 5,
+                   :a-mop-index 1,
+                   :b-mop-index 1}],
+                 :type :G2-item}]
+        ;; Without explicit transaction order specified, the rw/ww edges will not be inferred.
+        (is (= {:valid? true}
+               (c {:consistency-models [:serializable]}
+                  h)))
+        ;; With explicitly specified transaction order, the ww and rw edges will be inferred and G2-item should manifest.
+        (is (= {:valid? false
+                :anomaly-types [:G2-item]
+                :not       #{:repeatable-read}
+                :anomalies {:G2-item [msg]}}
+               (c {:consistency-models [:serializable] 
+                   ;; Txn commit order: T1 -> T3 -> T4 -> T2    
+                   :transaction-order {
+                                       0 1 
+                                       1 4 
+                                       2 2 
+                                       3 3}}
+                  h)))
+        ))
+
     (testing "G1c"
       (let [; T2 observes T1's write of x, and vice versa on y.
             t1 (op "wx1ry1")


### PR DESCRIPTION
As discussed in #30, this change allows optional transaction version order information to be passed in to the `rw_register` test checker, enabling inference of a wider range of dependency edge types (e.g. `ww` and `rw`). This version info is passed in as a map from completed transaction event indices to the version for that transaction, which for now we assume is some totally ordered numeric value.

The implementation is straightforward, though I am no Clojure expert so open to comments on making things more idiomatic on that front. Basically, we just (1) augment the given history with version tags based on the transaction map that was passed in (2) sort all writes to each key by their version and then (3) construct the version graph for each key based on this list of sorted writes per key. Happy to add some more thorough test cases if you'd like, but putting this up as a first draft. 

Also, for reference, a basic prototype of a system making use of this idea can be seen [here](https://github.com/will62794/rocksdb/commit/0d0de3c73e113cc1cd9059a132afde3b42db3444), in RocksDB. Essentially, we instrument transaction writes upon commit so that the value written to each key is logged with its associated "[sequence number](https://github.com/facebook/rocksdb/wiki/Terminology)", which should be a unique numeric counter assigned to each transaction, and is thus adequate to serve as the "version" ordering information as discussed here, as it corresponds to visibility/commit ordering.