### PR TITLE
Fix deadlock

### DIFF
--- a/src/elle/core.clj
+++ b/src/elle/core.clj
@@ -377,6 +377,8 @@
   transitive reduction of that graph. We compute edges from txn a to subsequent
   invocations until a new operation b completes."
   [history]
+  ; Force lazy pair-index before fold to avoid nested fold deadlocks
+  (h/ensure-pair-index history)
   ; Our basic approach here is to iterate through the history, and for any
   ; given :ok op, create an edge from that :ok to the :ok or :info
   ; corresponding to subsequent :invokes--because our graph relates

--- a/src/elle/list_append.clj
+++ b/src/elle/list_append.clj
@@ -601,6 +601,7 @@
    ; ops can't contribute to the state. TODO: do we... want to start inferring
    ; deps for failed ops too? Might simplify the dirty-update codepath.
    (let [history       (h/possible history)
+         _ (h/ensure-pair-index history)
          sorted-values (sorted-values history)]
      ; Compute indices
      (let [append-index (h/task history append-index []
@@ -948,6 +949,8 @@
    (check {} history))
   ([opts history]
    (let [history      (h/client-ops history)
+         ; Force lazy index computations to avoid nested fold deadlocks
+         _ (h/ensure-pair-index history)
          g1a          (h/task history g1a [] (g1a-cases history))
          g1b          (h/task history g1b [] (g1b-cases history))
          internal     (h/task history internal [] (internal-cases history))
@@ -959,6 +962,7 @@
          ; We don't want to detect duplicates or incompatible orders for
          ; aborted txns.
          history+      (h/possible history)
+         _ (h/ensure-pair-index history+)
          dups          (h/task history dups [] (duplicates history+))
          sorted-values (h/task history sorted-values+ []
                                (sorted-values history+))


### PR DESCRIPTION
The lazy pair_index/by_index on SparseHistory were causing nested h/fold within fold subtasks, leading to a deadlock in the thread pool. Eagerly force pair_index and by_index (via .ensure_pair_index and .get_index) on the history before any fold operations start, so nested folds never occur.

Fixes #32